### PR TITLE
export the currently selected tab index instead of just the initial selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A tabs component for Svelte
 
 ## Props
 
-- `initialSelectedIndex` (number): The index of the tab to initially select, when the Tabs component is mounted.
+- `selectedTabIndex` (number): The index of the tab to initially select, when the Tabs component is mounted.
 
 ## Overriding styling
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-tabs",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "svelte": "src/index.js",
   "module": "dist/index.mjs",
   "main": "dist/index.js",

--- a/src/Tabs.svelte
+++ b/src/Tabs.svelte
@@ -6,7 +6,7 @@
   import { afterUpdate, setContext, onDestroy, onMount, tick } from 'svelte';
   import { writable } from 'svelte/store';
 
-  export let initialSelectedIndex = 0;
+  export let selectedTabIndex = 0;
 
   const tabElements = [];
   const tabs = [];
@@ -31,9 +31,9 @@
   }
 
   function selectTab(tab) {
-    const index = tabs.indexOf(tab);
+    selectedTabIndex = tabs.indexOf(tab);
     selectedTab.set(tab);
-    selectedPanel.set(panels[index]);
+    selectedPanel.set(panels[selectedTabIndex]);
   }
 
   setContext(TABS, {
@@ -59,7 +59,7 @@
   });
 
   onMount(() => {
-    selectTab(tabs[initialSelectedIndex]);
+    selectTab(tabs[selectedTabIndex]);
   });
 
   afterUpdate(() => {
@@ -68,6 +68,11 @@
       labeledBy.update(labeledByData => ({...labeledByData, [panels[i].id]: tabs[i].id}));
     }
   });
+
+  $: selectedTabIndex, ()=>{
+    selectedTab.set(tabs[selectedTabIndex]);
+    selectedPanel.set(panels[selectedTabIndex]);
+  };
 
   async function handleKeyDown(event) {
     if (event.target.classList.contains('svelte-tabs__tab')) {


### PR DESCRIPTION
I needed this for a project and thought I'd propose the PR if you wanted to merge it.
This would need a minor version bump since it breaks backwards compatibility by removing the `initialSelectedIndex` bind.